### PR TITLE
Fix post list title hover and open post links in new tab

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -63,6 +63,14 @@
     <!-- End Google Tag Manager (noscript) -->
     </body>
 
+    <!-- Open post content links in new tab -->
+    <script>
+        document.querySelectorAll('.post-content a').forEach(function(link) {
+            link.setAttribute('target', '_blank');
+            link.setAttribute('rel', 'noopener noreferrer');
+        });
+    </script>
+
     <!--jquery script for sticky toc-->
     <script>
         window.onscroll = function() {myFunction()};

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -644,8 +644,10 @@ body,
 
     .page-title {
         border-bottom: 0px !important;
+        text-decoration: none !important;
         &:hover {
             border-bottom: 1px solid $theme-color !important;
+            text-decoration: none !important;
         }
         &,
         &:visited {


### PR DESCRIPTION
## Summary
- Fix double underline on post list titles on hover (border-bottom + text-decoration were both showing)
- Open all links inside post content in a new tab (`target="_blank"` with `rel="noopener noreferrer"`)

## Test plan
- [ ] Visit a post list page and hover over a title — should show a single underline only
- [ ] Open a post and click any markdown link — should open in a new tab
- [ ] Verify nav/footer links are unaffected (still open in same tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)